### PR TITLE
Allow residual, refresh_jacobian to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,19 +67,21 @@ impl Model {
 impl NonlinearSystem for Model {
     type Real = f64;
     type Layout = Layout;
+    type Error = &'static str,
 
     fn layout(&self) -> &Self::Layout { &self.lay }
     fn jacobian(&self) -> &dyn JacobianCache<Self::Real> { &self.jac }
     fn jacobian_mut(&mut self) -> &mut dyn JacobianCache<Self::Real> { &mut self.jac }
 
-    fn residual(&self, x: &[f64], out: &mut [f64]) {
+    fn residual(&self, x: &[f64], out: &mut [f64]) -> Result<(), Self::Error> {
         // f1 = sin(x) + y
         // f2 = x + exp(y) - 1
         out[0] = x[0].sin() + x[1];
         out[1] = x[0] + x[1].exp() - 1.0;
+        Ok(())
     }
 
-    fn refresh_jacobian(&mut self, x: &[f64]) {
+    fn refresh_jacobian(&mut self, x: &[f64]) -> Result<(), Self::Error> {
         // J = [[cos(x), 1],
         //      [     1, exp(y)]] in CSC (col-major): (0,0),(1,0),(0,1),(1,1)
         let v = self.jac.values_mut();
@@ -87,6 +89,7 @@ impl NonlinearSystem for Model {
         v[1] = 1.0;
         v[2] = 1.0;
         v[3] = x[1].exp();
+        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,15 +44,20 @@ impl<T> Pattern<T> {
 pub trait NonlinearSystem {
     type Real: num_traits::Float;
     type Layout: RowMap;
+    type Error;
 
     fn layout(&self) -> &Self::Layout;
     fn jacobian(&self) -> &dyn JacobianCache<Self::Real>;
     fn jacobian_mut(&mut self) -> &mut dyn JacobianCache<Self::Real>;
-    fn residual(&self, x: &[Self::Real], out: &mut [Self::Real]);
-    fn refresh_jacobian(&mut self, x: &[Self::Real]);
+    fn residual(&self, x: &[Self::Real], out: &mut [Self::Real]) -> Result<(), Self::Error>;
+    fn refresh_jacobian(&mut self, x: &[Self::Real]) -> Result<(), Self::Error>;
 
-    fn jacobian_dense(&mut self, x: &[Self::Real], jac: &mut faer::mat::Mat<Self::Real>) {
-        self.refresh_jacobian(x);
+    fn jacobian_dense(
+        &mut self,
+        x: &[Self::Real],
+        jac: &mut faer::mat::Mat<Self::Real>,
+    ) -> Result<(), Self::Error> {
+        self.refresh_jacobian(x)?;
         let sparse = self.jacobian().attach();
         jac.fill(Self::Real::zero());
         let row_idx = sparse.symbolic().row_idx();
@@ -63,12 +68,13 @@ pub trait NonlinearSystem {
                 jac[(row_idx[idx], col)] = vals[idx];
             }
         }
+        Ok(())
     }
 }
 
-pub trait LinearSolver<T: ComplexField<Real = T>, M> {
-    fn factor(&mut self, a: &M) -> SolverResult<()>;
-    fn solve_in_place(&mut self, rhs: &mut Mat<T>) -> SolverResult<()>;
+pub trait LinearSolver<T: ComplexField<Real = T>, M, E> {
+    fn factor(&mut self, a: &M) -> SolverResult<(), E>;
+    fn solve_in_place(&mut self, rhs: &mut Mat<T>) -> SolverResult<(), E>;
 }
 
 pub trait JacobianCache<T /* Real */> {
@@ -82,17 +88,25 @@ pub trait JacobianCache<T /* Real */> {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct SolverError;
+pub enum SolverError<E> {
+    /// Problem within the solver internals
+    Solver,
+    /// Problem in the user's nonlinear system.
+    NonLinearSystem(E),
+}
 
-impl Display for SolverError {
+impl<E: std::fmt::Display> Display for SolverError<E> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str("solver error")
+        match self {
+            SolverError::Solver => f.write_str("solver error"),
+            SolverError::NonLinearSystem(err) => err.fmt(f),
+        }
     }
 }
 
-impl std::error::Error for SolverError {}
+impl<E> std::error::Error for SolverError<E> where E: std::fmt::Debug + std::fmt::Display {}
 
-pub type SolverResult<T> = Result<T, error_stack::Report<SolverError>>;
+pub type SolverResult<T, E> = Result<T, error_stack::Report<SolverError<E>>>;
 
 static RAYON_INIT: OnceLock<usize> = OnceLock::new();
 
@@ -188,6 +202,7 @@ mod tests {
     impl NonlinearSystem for Model {
         type Real = f64;
         type Layout = TwoVarLayout;
+        type Error = &'static str;
 
         fn layout(&self) -> &Self::Layout {
             &self.layout
@@ -200,19 +215,21 @@ mod tests {
             &mut self.jac
         }
 
-        fn residual(&self, x: &[Self::Real], out: &mut [Self::Real]) {
+        fn residual(&self, x: &[Self::Real], out: &mut [Self::Real]) -> Result<(), Self::Error> {
             let (xx, yy) = (x[0], x[1]);
             out[0] = xx + yy - 3.0;
             out[1] = xx * xx + yy - 3.0;
+            Ok(())
         }
 
-        fn refresh_jacobian(&mut self, x: &[Self::Real]) {
+        fn refresh_jacobian(&mut self, x: &[Self::Real]) -> Result<(), Self::Error> {
             let xx = x[0];
             let v = self.jac.values_mut();
             v[0] = 1.0;
             v[1] = 2.0 * xx;
             v[2] = 1.0;
             v[3] = 1.0;
+            Ok(())
         }
     }
 

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -92,8 +92,12 @@ impl<T: ComplexField<Real = T>> Default for FaerLu<T> {
     }
 }
 
-impl<T: ComplexField<Real = T>> LinearSolver<T, SparseColMatRef<'_, usize, T>> for FaerLu<T> {
-    fn factor(&mut self, a: &SparseColMatRef<'_, usize, T>) -> SolverResult<()> {
+impl<T, E> LinearSolver<T, SparseColMatRef<'_, usize, T>, E> for FaerLu<T>
+where
+    T: ComplexField<Real = T>,
+    E: std::fmt::Debug + std::fmt::Display + Sync + Send + 'static,
+{
+    fn factor(&mut self, a: &SparseColMatRef<'_, usize, T>) -> SolverResult<(), E> {
         let now = pattern_sig(a);
         let par = Par::rayon(0);
 
@@ -112,13 +116,13 @@ impl<T: ComplexField<Real = T>> LinearSolver<T, SparseColMatRef<'_, usize, T>> f
             self.sym = Some(
                 factorize_symbolic_lu(a.symbolic(), LuSymbolicParams::default())
                     .attach_printable("LU symbolic factorization failed")
-                    .change_context(SolverError)?,
+                    .change_context(SolverError::Solver)?,
             );
 
             let scratch_size = self
                 .sym
                 .as_ref()
-                .ok_or(SolverError)
+                .ok_or(SolverError::Solver)
                 .attach_printable("Symbolic factorization missing")?
                 .factorize_numeric_lu_scratch::<T>(par, Default::default());
             self.scratch = Some(MemBuffer::new(scratch_size));
@@ -128,26 +132,26 @@ impl<T: ComplexField<Real = T>> LinearSolver<T, SparseColMatRef<'_, usize, T>> f
         let mut stack = MemStack::new(
             self.scratch
                 .as_mut()
-                .ok_or(SolverError)
+                .ok_or(SolverError::Solver)
                 .attach_printable("Scratch buffer not initialized")?,
         );
 
         self.sym
             .as_ref()
-            .ok_or(SolverError)
+            .ok_or(SolverError::Solver)
             .attach_printable("Symbolic factorization not available")?
             .factorize_numeric_lu(&mut self.num, *a, par, &mut stack, Default::default())
             .attach_printable("Numeric LU factorization failed")
-            .change_context(SolverError)?;
+            .change_context(SolverError::Solver)?;
 
         Ok(())
     }
 
-    fn solve_in_place(&mut self, rhs: &mut Mat<T>) -> SolverResult<()> {
+    fn solve_in_place(&mut self, rhs: &mut Mat<T>) -> SolverResult<(), E> {
         let mut stack = MemStack::new(
             self.scratch
                 .as_mut()
-                .ok_or(SolverError)
+                .ok_or(SolverError::Solver)
                 .attach_printable("Scratch buffer not available for solve")?,
         );
 
@@ -155,7 +159,7 @@ impl<T: ComplexField<Real = T>> LinearSolver<T, SparseColMatRef<'_, usize, T>> f
             LuRef::new_unchecked(
                 self.sym
                     .as_ref()
-                    .ok_or(SolverError)
+                    .ok_or(SolverError::Solver)
                     .attach_printable("Symbolic factorization not available for solve")?,
                 &self.num,
             )
@@ -176,17 +180,21 @@ impl<T: ComplexField<Real = T>> Default for DenseLu<T> {
     }
 }
 
-impl<T: ComplexField<Real = T>> LinearSolver<T, Mat<T>> for DenseLu<T> {
-    fn factor(&mut self, a: &Mat<T>) -> SolverResult<()> {
+impl<T, E> LinearSolver<T, Mat<T>, E> for DenseLu<T>
+where
+    T: ComplexField<Real = T>,
+    E: std::fmt::Debug + std::fmt::Display + Sync + Send + 'static,
+{
+    fn factor(&mut self, a: &Mat<T>) -> SolverResult<(), E> {
         self.lu = Some(a.full_piv_lu());
         Ok(())
     }
 
-    fn solve_in_place(&mut self, rhs: &mut Mat<T>) -> SolverResult<()> {
+    fn solve_in_place(&mut self, rhs: &mut Mat<T>) -> SolverResult<(), E> {
         let lu = self
             .lu
             .as_ref()
-            .ok_or(SolverError)
+            .ok_or(SolverError::Solver)
             .attach_printable("Dense LU not factorized")?;
 
         let solution = lu.solve(rhs.as_ref());

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -111,11 +111,12 @@ fn newton_iterate<M, F, Cb>(
     cfg: super::NewtonCfg<M::Real>,
     mut solve_into: F,
     mut on_iter: Cb,
-) -> SolverResult<Iterations>
+) -> SolverResult<Iterations, M::Error>
 where
     M: NonlinearSystem,
     M::Real: ComplexField<Real = M::Real> + Float + Zero + One + ToPrimitive,
-    F: FnMut(&mut M, &[M::Real], &[M::Real], &mut [M::Real]) -> SolverResult<()>,
+    M::Error: std::fmt::Debug + std::fmt::Display + Send + Sync + 'static,
+    F: FnMut(&mut M, &[M::Real], &[M::Real], &mut [M::Real]) -> SolverResult<(), M::Error>,
     Cb: FnMut(&IterationStats<M::Real>) -> Control,
 {
     let n = model.layout().dim();
@@ -129,7 +130,9 @@ where
     let mut f_trial = vec![M::Real::zero(); n];
 
     for iter in 0..cfg.max_iter {
-        model.residual(x, &mut f);
+        model
+            .residual(x, &mut f)
+            .map_err(SolverError::NonLinearSystem)?;
         let res = f
             .iter()
             .map(|&v| v.abs())
@@ -143,7 +146,7 @@ where
             }),
             Control::Cancel
         ) {
-            return Err(Report::new(SolverError).attach_printable("solve cancelled"));
+            return Err(Report::new(SolverError::Solver).attach_printable("solve cancelled"));
         }
         if res < cfg.tol {
             return Ok(iter + 1);
@@ -181,7 +184,9 @@ where
                     for i in 0..n {
                         x_trial[i] = x[i] + alpha * dx[i];
                     }
-                    model.residual(&x_trial, &mut f_trial);
+                    model
+                        .residual(&x_trial, &mut f_trial)
+                        .map_err(SolverError::NonLinearSystem)?;
                     let res_try = f_trial
                         .iter()
                         .map(|&v| v.abs())
@@ -200,7 +205,7 @@ where
                 }
 
                 if !step_applied {
-                    return Err(Report::new(SolverError)
+                    return Err(Report::new(SolverError::Solver)
                         .attach_printable("divergence guard: line search failed"));
                 }
             }
@@ -215,7 +220,7 @@ where
         last_res = res;
     }
 
-    Err(Report::new(SolverError).attach_printable(format!(
+    Err(Report::new(SolverError::Solver).attach_printable(format!(
         "Newton solver did not converge after {} iterations",
         cfg.max_iter
     )))
@@ -225,10 +230,11 @@ pub fn solve<M>(
     model: &mut M,
     x: &mut [M::Real],
     cfg: super::NewtonCfg<M::Real>,
-) -> SolverResult<Iterations>
+) -> SolverResult<Iterations, M::Error>
 where
     M: NonlinearSystem,
     M::Real: ComplexField<Real = M::Real> + Float + Zero + One + ToPrimitive,
+    M::Error: std::fmt::Display + std::fmt::Debug + Send + Sync + 'static,
 {
     solve_cb(model, x, cfg, |_| Control::Continue)
 }
@@ -238,9 +244,10 @@ pub fn solve_cb<M, Cb>(
     x: &mut [M::Real],
     cfg: super::NewtonCfg<M::Real>,
     on_iter: Cb,
-) -> SolverResult<Iterations>
+) -> SolverResult<Iterations, M::Error>
 where
     M: NonlinearSystem,
+    M::Error: std::fmt::Display + std::fmt::Debug + Send + Sync + 'static,
     M::Real: ComplexField<Real = M::Real> + Float + Zero + One + ToPrimitive,
     Cb: FnMut(&IterationStats<M::Real>) -> Control,
 {
@@ -266,11 +273,12 @@ pub fn solve_sparse_cb<M, L, Cb>(
     lin: &mut L,
     cfg: super::NewtonCfg<M::Real>,
     on_iter: Cb,
-) -> SolverResult<Iterations>
+) -> SolverResult<Iterations, M::Error>
 where
     M: NonlinearSystem,
-    L: for<'a> LinearSolver<M::Real, SparseColMatRef<'a, usize, M::Real>>,
+    L: for<'a> LinearSolver<M::Real, SparseColMatRef<'a, usize, M::Real>, M::Error>,
     M::Real: ComplexField<Real = M::Real> + Float + Zero + One + ToPrimitive,
+    M::Error: std::fmt::Display + std::fmt::Debug + Send + Sync + 'static,
     Cb: FnMut(&IterationStats<M::Real>) -> Control,
 {
     let n = model.layout().dim();
@@ -281,7 +289,9 @@ where
         x,
         cfg,
         |model, x, f, dx| {
-            model.refresh_jacobian(x);
+            model
+                .refresh_jacobian(x)
+                .map_err(SolverError::NonLinearSystem)?;
             lin.factor(&model.jacobian().attach())?;
 
             rhs.col_mut(0)
@@ -307,11 +317,12 @@ pub fn solve_dense_cb<M, L, Cb>(
     lu: &mut L,
     cfg: super::NewtonCfg<M::Real>,
     on_iter: Cb,
-) -> SolverResult<Iterations>
+) -> SolverResult<Iterations, M::Error>
 where
     M: NonlinearSystem,
-    L: LinearSolver<M::Real, Mat<M::Real>>,
+    L: LinearSolver<M::Real, Mat<M::Real>, M::Error>,
     M::Real: ComplexField<Real = M::Real> + Float + Zero + One + ToPrimitive,
+    M::Error: std::fmt::Display + std::fmt::Debug + Send + Sync + 'static,
     Cb: FnMut(&IterationStats<M::Real>) -> Control,
 {
     let n = model.layout().dim();
@@ -323,7 +334,9 @@ where
         x,
         cfg,
         |model, x, f, dx| {
-            model.jacobian_dense(x, &mut jac);
+            model
+                .jacobian_dense(x, &mut jac)
+                .map_err(|e| Report::new(SolverError::NonLinearSystem(e)))?;
             lu.factor(&jac)?;
             for (i, &fi) in f.iter().enumerate() {
                 rhs[(i, 0)] = -fi;


### PR DESCRIPTION
The user's NonLinearSystem calculates the matrices that newton_faer solves. However, the user's `residual` and `refresh_jacobian` implementations might do some fallible operation (e.g. looking up a variable in a collection). Right now, users can only handle that result by panicking or silently returning invalid data and signalling something out-of-band about the failure.

This PR makes NonLinearSystem generic over a type `Error`, and updates `newton_faer::SolverResult` to contain a case for that `Error`. That way users can fail their `residual` or `refresh_jacobian` code without panicking or silently ignoring data. They'll just get an error when calling `solve`, like how other solver errors are handled.